### PR TITLE
Invalid requirements during installation.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,14 +1,13 @@
-pip install SpeechRecognition
-pip install pyttsx3
-pip install pywhatkit
-pip install datetime
-pip install wikipedia
-pip install pyjokes
-pip install math
-pip install vosk
-pip install rasa
-pip install requests
-pip install owm
-pip install rasa
-pip install vosk
-pip install wx
+SpeechRecognition
+pyttsx3
+pywhatkit
+datetime
+wikipedia
+pyjokes
+vosk
+rasa
+requests
+pyowm
+rasa
+vosk
+wxPython


### PR DESCRIPTION
The installation was giving a "_Invalid requirement_" and "_Could not find a version that satisfies requirements_" errors.
![Screenshot 2021-09-29 16 30 14](https://user-images.githubusercontent.com/55005341/135357725-f4f6bac5-4454-4878-996c-a67e9192ee3b.png)
![Screenshot 2021-09-29 16 30 25](https://user-images.githubusercontent.com/55005341/135357727-f724f255-31de-4976-9483-e4f5f1ff12ae.png)

The requirements were not installed correctly due to bad syntax on file and bad module names.
It was fixed and now the requirements are installed as they should be.