### PR TITLE
WolframAlpha added to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ pyowm
 rasa
 vosk
 wxPython
+wolframalpha


### PR DESCRIPTION
_**wolframalpha**_ module was missing as a requirement for the program.
It was added to the list.