### PR TITLE
Added PyAudio as requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,5 @@ pyowm
 rasa
 vosk
 wxPython
+wolframalpha
+PyAudio


### PR DESCRIPTION
Added PyAudio to requirements since it is needed to the speech recognition to work.
It could be installed or not depending on the system.

If it didn't install try doing it with `pip install pipwin` and then `pipwin install pyaudio`